### PR TITLE
added custom arctos kinematics and new default settings

### DIFF
--- a/uCNC/cnc_config.h
+++ b/uCNC/cnc_config.h
@@ -67,11 +67,11 @@ extern "C"
 	 * */
 
 #ifndef AXIS_COUNT
-#define AXIS_COUNT 3
+#define AXIS_COUNT 6
 #endif
 
 #ifndef KINEMATIC
-#define KINEMATIC KINEMATIC_CARTESIAN
+#define KINEMATIC KINEMATIC_ARCTOS
 #endif
 
 	/**
@@ -113,25 +113,18 @@ extern "C"
 	 * define different settings for each axis.
 	 */
 
-	// #define DEFAULT_DIR_INV_MASK 0
-	// #define DEFAULT_LIMIT_INV_MASK 0
-	// #define DEFAULT_SOFT_LIMITS_ENABLED 0
-	// #define DEFAULT_HARD_LIMITS_ENABLED 0
-	// #define DEFAULT_HOMING_ENABLED 0
-	// #define DEFAULT_HOMING_DIR_INV_MASK 0
-	// #define DEFAULT_HOMING_FAST 50
-	// #define DEFAULT_HOMING_SLOW 10
-	// #define DEFAULT_HOMING_OFFSET 2
-	// #define DEFAULT_STEP_PER_MM 200
-	// #define DEFAULT_STEP_PER_MM_PER_AXIS {200, 200, 200}
-	// #define DEFAULT_MAX_FEED 500
-	// #define DEFAULT_MAX_FEED_PER_AXIS {500, 500, 500}
-	// #define DEFAULT_ACCEL 10
-	// #define DEFAULT_ACCEL_PER_AXIS {10, 10, 10}
-	// #define DEFAULT_MAX_DIST 200
-	// #define DEFAULT_MAX_DIST_PER_AXIS {200, 200, 50}
-	// #define DEFAULT_ARC_TOLERANCE 0.002
-	// #define DEFAULT_DEBOUNCE_MS 250
+	#define DEFAULT_LIMIT_INV_MASK 255
+	#define DEFAULT_HARD_LIMITS_ENABLED 1
+	#define DEFAULT_HOMING_ENABLED 1
+	#define DEFAULT_HOMING_FAST 170
+	#define DEFAULT_HOMING_SLOW 60
+	#define DEFAULT_HOMING_OFFSET 10
+	#define DEFAULT_STEP_PER_MM_PER_AXIS {60.000, 700.000, 693.000, 200.000, 140.000, 140.000} // 1 mm = 10 degrees, 200 steps = 360 degrees
+	#define DEFAULT_MAX_FEED_PER_AXIS {3000, 350, 600, 2000, 2500, 2500} // 36000mm/min = 60deg/sec
+	#define DEFAULT_ACCEL_PER_AXIS {50, 50, 50, 50, 50, 50}
+	#define DEFAULT_MAX_DIST_PER_AXIS {360, 180, 180, 180, 3000, 3000} // 360 degrees max rotation on each axis.
+	#define DEFAULT_ARC_TOLERANCE 0.002
+	#define DEFAULT_DEBOUNCE_MS 250
 
 #if defined(KINEMATIC_DELTA)
 	// #define DEFAULT_LIN_DELTA_ARM_LENGTH 230

--- a/uCNC/src/hal/kinematics/kinematic_arctos.c
+++ b/uCNC/src/hal/kinematics/kinematic_arctos.c
@@ -1,0 +1,235 @@
+/*
+		Name: kinematic_cartesian.c
+		Description: Implements all kinematics math equations to translate the motion of a cartesian machine.
+				Also implements the homing motion for this type of machine.
+
+		Copyright: Copyright (c) João Martins
+		Author: João Martins
+		Date: 26/09/2019
+
+		µCNC is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+
+		µCNC is distributed WITHOUT ANY WARRANTY;
+		Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+		See the	GNU General Public License for more details.
+*/
+
+#include "../../cnc.h"
+
+#if (KINEMATIC == KINEMATIC_ARCTOS)
+#include <stdio.h>
+#include <math.h>
+
+void kinematics_init(void)
+{
+}
+
+void kinematics_apply_inverse(float *axis, int32_t *steps)
+{
+	for (uint8_t i = 0; i < 4; i++)
+	{
+		steps[i] = (int32_t)lroundf(g_settings.step_per_mm[i] * axis[i]);
+	}
+	steps[4] = (int32_t)lroundf(g_settings.step_per_mm[4] * (axis[AXIS_C] - axis[AXIS_B]));
+	steps[5] = (int32_t)lroundf(g_settings.step_per_mm[5] * (axis[AXIS_C] + axis[AXIS_B]));
+}
+
+void kinematics_apply_forward(int32_t *steps, float *axis)
+{
+	for (uint8_t i = 0; i < 4; i++)
+	{
+		axis[i] = (((float)steps[i]) / g_settings.step_per_mm[i]);
+	}
+  axis[AXIS_B] = (float)(0.5f * (float)(steps[4] + steps[5]) / g_settings.step_per_mm[4]);
+  axis[AXIS_C] = (float)(0.5f * (float)(steps[4] - steps[5]) / g_settings.step_per_mm[5]);
+
+}
+
+uint8_t kinematics_home(void)
+{
+	float target[AXIS_COUNT];
+
+
+
+#ifndef HOMING_CYCLE_0_AXIS_MASK
+#define HOMING_CYCLE_0_AXIS_MASK         AXIS_Z_HOMING_MASK
+#define HOMING_CYCLE_0_ERROR             KINEMATIC_HOMING_ERROR_Z
+#define HOMING_CYCLE_0_LIMIT_MASK        LINACT2_LIMIT_MASK
+#endif  // HOMING_CYCLE_0_AXIS_MASK
+
+#ifndef ENABLE_XY_SIMULTANEOUS_HOMING
+
+#ifndef HOMING_CYCLE_1_AXIS_MASK
+#define HOMING_CYCLE_1_AXIS_MASK         AXIS_X_HOMING_MASK
+#define HOMING_CYCLE_1_ERROR             KINEMATIC_HOMING_ERROR_X
+#define HOMING_CYCLE_1_LIMIT_MASK        LINACT0_LIMIT_MASK
+#endif  // HOMING_CYCLE_1_AXIS_MASK
+
+#ifndef HOMING_CYCLE_2_AXIS_MASK
+#define HOMING_CYCLE_2_AXIS_MASK         AXIS_Y_HOMING_MASK
+#define HOMING_CYCLE_2_ERROR             KINEMATIC_HOMING_ERROR_Y
+#define HOMING_CYCLE_2_LIMIT_MASK        LINACT1_LIMIT_MASK
+#endif  // HOMING_CYCLE_2_AXIS_MASK
+
+#ifndef HOMING_CYCLE_3_AXIS_MASK
+#define HOMING_CYCLE_3_AXIS_MASK         0
+#define HOMING_CYCLE_3_ERROR             /*not-used*/
+#define HOMING_CYCLE_3_LIMIT_MASK        /*not-used*/
+#endif  // HOMING_CYCLE_3_AXIS_MASK
+
+#else // ENABLE_XY_SIMULTANEOUS_HOMING
+
+#ifndef HOMING_CYCLE_1_AXIS_MASK
+#define HOMING_CYCLE_1_AXIS_MASK         (AXIS_X_HOMING_MASK | AXIS_Y_HOMING_MASK)
+#define HOMING_CYCLE_1_ERROR             KINEMATIC_HOMING_ERROR_XY
+#define HOMING_CYCLE_1_LIMIT_MASK        (LINACT0_LIMIT_MASK | LINACT1_LIMIT_MASK)
+#endif  // HOMING_CYCLE_1_AXIS_MASK
+
+#ifndef HOMING_CYCLE_2_AXIS_MASK
+#define HOMING_CYCLE_2_AXIS_MASK         AXIS_X_HOMING_MASK
+#define HOMING_CYCLE_2_ERROR             KINEMATIC_HOMING_ERROR_X
+#define HOMING_CYCLE_2_LIMIT_MASK        LINACT0_LIMIT_MASK
+#endif  // HOMING_CYCLE_2_AXIS_MASK
+
+#ifndef HOMING_CYCLE_3_AXIS_MASK
+#define HOMING_CYCLE_3_AXIS_MASK         AXIS_Y_HOMING_MASK
+#define HOMING_CYCLE_3_ERROR             KINEMATIC_HOMING_ERROR_Y
+#define HOMING_CYCLE_3_LIMIT_MASK        LINACT1_LIMIT_MASK
+#endif  // HOMING_CYCLE_3_AXIS_MASK
+
+#endif // ENABLE_XY_SIMULTANEOUS_HOMING
+
+#ifndef HOMING_CYCLE_4_AXIS_MASK
+#define HOMING_CYCLE_4_AXIS_MASK         AXIS_A_HOMING_MASK
+#define HOMING_CYCLE_4_ERROR             KINEMATIC_HOMING_ERROR_A
+#define HOMING_CYCLE_4_LIMIT_MASK        LINACT3_LIMIT_MASK
+#endif  // HOMING_CYCLE_4_AXIS_MASK
+
+#ifndef HOMING_CYCLE_5_AXIS_MASK
+#define HOMING_CYCLE_5_AXIS_MASK         AXIS_B_HOMING_MASK
+#define HOMING_CYCLE_5_ERROR             KINEMATIC_HOMING_ERROR_B
+#define HOMING_CYCLE_5_LIMIT_MASK        LINACTB_LIMIT_MASK
+#endif  // HOMING_CYCLE_5_AXIS_MASK
+
+#ifndef HOMING_CYCLE_6_AXIS_MASK
+#define HOMING_CYCLE_6_AXIS_MASK         AXIS_C_HOMING_MASK
+#define HOMING_CYCLE_6_ERROR             KINEMATIC_HOMING_ERROR_C
+#define HOMING_CYCLE_6_LIMIT_MASK        LINACT5_LIMIT_MASK
+#endif  // HOMING_CYCLE_5_AXIS_MASK
+
+// Home the axes in the order specified 0,1,2,3,4,5
+// corresponding to the X,Y,Z,A,B,C axes mapped to each
+// of them.
+
+#ifndef DISABLE_ALL_LIMITS
+#if HOMING_CYCLE_0_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_0_AXIS_MASK, HOMING_CYCLE_0_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_0_ERROR;
+	}
+#endif
+
+#if HOMING_CYCLE_1_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_1_AXIS_MASK, HOMING_CYCLE_1_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_1_ERROR;
+	}
+#endif
+
+#if HOMING_CYCLE_2_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_2_AXIS_MASK, HOMING_CYCLE_2_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_2_ERROR;
+	}
+#endif
+
+
+#if HOMING_CYCLE_3_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_3_AXIS_MASK, HOMING_CYCLE_3_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_3_ERROR;
+	}
+#endif
+
+#if HOMING_CYCLE_4_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_4_AXIS_MASK, HOMING_CYCLE_4_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_4_ERROR;
+	}
+#endif
+
+#if HOMING_CYCLE_5_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_5_AXIS_MASK, HOMING_CYCLE_5_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_5_ERROR;
+	}
+#endif
+
+#if HOMING_CYCLE_6_AXIS_MASK != 0
+	if (mc_home_axis(HOMING_CYCLE_6_AXIS_MASK, HOMING_CYCLE_6_LIMIT_MASK))
+	{
+		return HOMING_CYCLE_6_ERROR;
+	}
+#endif
+
+	cnc_unlock(true);
+	motion_data_t block_data = {0};
+	mc_get_position(target);
+
+	for (uint8_t i = 0; i < AXIS_COUNT; i++)
+	{
+		target[i] += ((g_settings.homing_dir_invert_mask & (1 << i)) ? -g_settings.homing_offset : g_settings.homing_offset);
+	}
+
+	block_data.feed = g_settings.homing_fast_feed_rate;
+	block_data.spindle = 0;
+	block_data.dwell = 0;
+	// starts offset and waits to finnish
+	mc_line(target, &block_data);
+	itp_sync();
+#endif
+
+#ifdef SET_ORIGIN_AT_HOME_POS
+	memset(target, 0, sizeof(target));
+#else
+for (uint8_t i = AXIS_COUNT; i != 0;)
+{
+	i--;
+	target[i] = (!(g_settings.homing_dir_invert_mask & (1 << i)) ? 0 : g_settings.max_distance[i]);
+}
+#endif
+
+	// reset position
+	itp_reset_rt_position(target);
+
+	return STATUS_OK;
+}
+
+bool kinematics_check_boundaries(float *axis)
+{
+	if (!g_settings.soft_limits_enabled || cnc_get_exec_state(EXEC_HOMING))
+	{
+		return true;
+	}
+
+	for (uint8_t i = AXIS_COUNT; i != 0;)
+	{
+		i--;
+#ifdef SET_ORIGIN_AT_HOME_POS
+		float value = !(g_settings.homing_dir_invert_mask & (1 << i)) ? axis[i] : -axis[i];
+#else
+		float value = axis[i];
+#endif
+		if (value > g_settings.max_distance[i] || value < 0)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+#endif

--- a/uCNC/src/hal/kinematics/kinematic_arctos.h
+++ b/uCNC/src/hal/kinematics/kinematic_arctos.h
@@ -1,10 +1,10 @@
 /*
-	Name: kinematics.h
-	Description: Defines the available machine types.
+	Name: kinematic_cartesian.h
+	Description: Custom kinematics definitions for cartesian machine
 
 	Copyright: Copyright (c) João Martins
 	Author: João Martins
-	Date: 11/11/2019
+	Date: 06/02/2020
 
 	µCNC is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -16,23 +16,17 @@
 	See the	GNU General Public License for more details.
 */
 
-#ifndef KINEMATICS_H
-#define KINEMATICS_H
+#ifndef KINEMATIC_ARCTOS_H
+#define KINEMATIC_ARCTOS_H
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#define KINEMATIC_CARTESIAN 1
-#define KINEMATIC_COREXY 2
-#define KINEMATIC_LINEAR_DELTA 3
-#define KINEMATIC_DELTA 4
-#define KINEMATIC_SCARA 5
-#define KINEMATIC_ARCTOS 6
+#define KINEMATIC_TYPE_STR "AR"
 
 #ifdef __cplusplus
 }
 #endif
-
 #endif

--- a/uCNC/src/hal/kinematics/kinematicdefs.h
+++ b/uCNC/src/hal/kinematics/kinematicdefs.h
@@ -67,6 +67,8 @@ extern "C"
 #include "kinematic_delta.h"
 #elif (KINEMATIC == KINEMATIC_SCARA)
 #include "kinematic_scara.h"
+#elif (KINEMATIC == KINEMATIC_ARCTOS)
+#include "kinematic_arctos.h"
 #else
 #error Kinematics not implemented
 #endif


### PR DESCRIPTION
The arctos kinematics are a combination of cartesian and corexy adapted for the BC axis. the cnc_config.h file also includes new setting defaults for step per mm, acceleration, and max speed for the open loop version. Might need slight adjustment for your personal build but should give a nice starting point.